### PR TITLE
Feature juanruizgci/test: activar JaCoCo y análisis SonarCloud + HealthControllerTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ develop, main ]
 
-# Para que Sonar comente en PRs
 permissions:
   contents: read
   pull-requests: write
@@ -14,55 +13,47 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      # 1) Checkout
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # 2) JDK 21
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: '21'
           cache: gradle
 
-      # 3) Hacer gradlew ejecutable (muy importante en Linux)
       - name: Make Gradle executable
         run: chmod +x gradlew
 
-      # 4) Cache de Gradle (acelera builds)
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      #  Primero pruebas + cobertura (genera el XML)
+      - name: Tests + JaCoCo
+        run: ./gradlew clean test jacocoTestReport --no-daemon
 
-      # 5) Compilar y testear
-      - name: Build & Test
-        run: ./gradlew clean build test --no-daemon
-
-      # 6) Subir reportes de tests (opcional)
-      - name: Upload test results
+      # (Opcional) Subir reportes para inspección
+      - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: build/test-results/test
+          name: reports
+          path: |
+            build/test-results/test
+            build/reports/tests/test
+            build/reports/jacoco/test
 
-      # 7) Análisis con SonarCloud (acción nueva, sin deprecaciones)
+      # Ahora sí: análisis en SonarCloud
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v2
+        uses: SonarSource/sonarcloud-github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: >
+            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+            -Dsonar.junit.reportPaths=build/test-results/test
+            -Dsonar.java.binaries=build/classes/java/main
+
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
 
-          
+
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'jacoco' // <— añadido para cobertura
 }
 
 group = 'com.reserva.cancha'
@@ -14,7 +15,9 @@ java {
     }
 }
 
-repositories { mavenCentral() }
+repositories {
+    mavenCentral()
+}
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -32,10 +35,20 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.36'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.36'
 
+    // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy tasks.named('jacocoTestReport') // genera reporte después de los tests
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true   // SonarCloud necesita este XML
+        html.required = true  // opcional, puedes abrirlo en navegador
+    }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,12 +8,12 @@ sonar.sources=src/main/java
 sonar.tests=src/test/java
 sonar.java.binaries=build/classes/java/main
 
-# Resultados de tests
+# Resultados de tests (JUnit)
 sonar.junit.reportPaths=build/test-results/test
 
-# Reporte de cobertura JaCoCo (muy importante)
-sonar.jacoco.reportPaths=build/jacoco/test.exec
+# Cobertura con JaCoCo (usar SOLO el XML)
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 
 # Codificación
 sonar.sourceEncoding=UTF-8
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,19 @@
+# Identificación del proyecto en SonarCloud
 sonar.projectKey=juansrg95_ReservaCanchaF
 sonar.organization=juansrg95
 sonar.host.url=https://sonarcloud.io
 
+# Código y tests
 sonar.sources=src/main/java
 sonar.tests=src/test/java
-sonar.java.binaries=build/classes
+sonar.java.binaries=build/classes/java/main
+
+# Resultados de tests
 sonar.junit.reportPaths=build/test-results/test
+
+# Reporte de cobertura JaCoCo (muy importante)
+sonar.jacoco.reportPaths=build/jacoco/test.exec
+sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+
+# Codificación
+sonar.sourceEncoding=UTF-8

--- a/src/test/java/com/reserva/cancha/controller/HealthControllerTest.java
+++ b/src/test/java/com/reserva/cancha/controller/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package com.reserva.cancha.controller;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HealthController.class)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void healthCheck_returns_ok_message() throws Exception {
+        mvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                // Si quieres exigir el texto exacto:
+                .andExpect(content().string("Backend OK - Rama feature-juanruizg"));
+
+        // Alternativa más flexible (si el texto podría cambiar un poco):
+        // .andExpect(content().string(org.hamcrest.Matchers.containsString("Backend OK")));
+    }
+}


### PR DESCRIPTION
- Agrego HealthController y test de /health con MockMvc
- Configuro JaCoCo (XML) y workflow CI para generar cobertura antes del scan
- SonarCloud debe leer: build/reports/jacoco/test/jacocoTestReport.xml
- Cómo probar: ./gradlew clean test jacocoTestReport
